### PR TITLE
feat: add duplicated test for checking how works AiBot

### DIFF
--- a/e2e-tests/others.test.js
+++ b/e2e-tests/others.test.js
@@ -268,8 +268,23 @@ test('Error validation: 404 status code & title on NGF page', async ({ page }) =
   });
 });
 
+test('Error validation: 404 status code & title on NGF page', async ({ page }) => {
+  let response = null;
+  await test.step('Open not existing page', async () => {
+    response = await page.goto(`${process.env.BASE_URL}/hades-2/builds/dystopianteddybear-aspect-of-charonsrghhfg`, {
+      waitUntil: 'domcontentloaded',
+    });
+  });
+  await test.step('Expected Result: 404 status code is present on the response', async () => {
+    expect(response.status()).toBe(404);
+  });
+  await test.step("Expected Result: '404' title is present on the page", async () => {
+    await expect(page.getByRole('heading', { name: '404' })).toBeVisible();
+  });
+});
+
 // hydrationLinks.forEach((link) => {
-//   test(`Check that hydration is ok on the featured profile: ${process.env.BASE_URL}${link}`, async ({ page }) => {
+//   test(`Check that hydration is ok on: ${process.env.BASE_URL}${link}`, async ({ page }) => {
 //     const consoleMessages = [];
 //     const pageErrors = [];
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an e2e test that verifies a nonexistent NGF build URL returns 404 and shows a '404' heading.
> 
> - **E2E Tests (`e2e-tests/others.test.js`)**:
>   - Add test validating 404 status and '404' heading for a nonexistent NGF build page (`/hades-2/builds/...`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce66a1c18c9169c18187a775f5232ec3c3768c16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->